### PR TITLE
přidání rumunské lokalizace

### DIFF
--- a/.github/workflows/php-package-ci.yml
+++ b/.github/workflows/php-package-ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ 7.4, 8.0, 8.1 ]
+        php: [ 8.0, 8.1 ]
     steps:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,11 @@
         }
     ],
     "require": {
-        "php": "7.4.* || 8.0.* || 8.1.*",
+        "php": "8.0.* || 8.1.*",
         "ext-mbstring": "*",
+        "ext-calendar": "*",
         "nette/utils": "~2.5.4|~3.0.0|~3.1.0|~3.2.0",
-        "nette/di": "~2.4.14|~3.0.0",
+        "nette/di": "~3.0.0",
         "nette/neon": "~2.4.3|~3.0"
     },
     "require-dev": {
@@ -29,6 +30,10 @@
         "psr-4": {
             "PdTests\\Holidays\\": "tests"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
-
 }

--- a/src/DI/Extension.php
+++ b/src/DI/Extension.php
@@ -11,6 +11,7 @@ final class Extension extends \Nette\DI\CompilerExtension
 
 		$builder = $this->getContainerBuilder();
 
+		/** @var \Nette\DI\Definitions\ServiceDefinition $holidayFacade */
 		$holidayFacade = $builder
 			->addDefinition($this->prefix('holidayFacade'))
 			->setFactory(\Pd\Holidays\HolidayFacade::class)
@@ -18,17 +19,18 @@ final class Extension extends \Nette\DI\CompilerExtension
 
 		$this->addLocalization($holidayFacade, \Pd\Holidays\Localizations\Czech::class, \Pd\Holidays\Localizations\ICzech::COUNTRY_CODE_CZECH);
 		$this->addLocalization($holidayFacade, \Pd\Holidays\Localizations\Slovak::class, \Pd\Holidays\Localizations\ISlovak::COUNTRY_CODE_SLOVAK);
+		$this->addLocalization($holidayFacade, \Pd\Holidays\Localizations\Romania::class, \Pd\Holidays\Localizations\IRomania::COUNTRY_CODE_ROMANIA);
 	}
 
 
-	private function addLocalization(\Nette\DI\ServiceDefinition $holidayFacade, string $localizationClass, string $countryCode): void
+	private function addLocalization(\Nette\DI\Definitions\ServiceDefinition $holidayFacade, string $localizationClass, string $countryCode): void
 	{
 		$builder = $this->getContainerBuilder();
 		$countryCodePrefix = \Nette\Utils\Strings::lower($countryCode);
 
 		$translations = \Nette\Neon\Neon::decode((string) \file_get_contents(__DIR__ . '/../Localizations/' . \Nette\Utils\Strings::lower(\Nette\Utils\Strings::substring($localizationClass, \strrpos($localizationClass, '\\') + 1)) . '.neon'));
 
-		$czechHolidayFactory = $builder
+		$holidayFactory = $builder
 			->addDefinition($this->prefix($countryCodePrefix . 'HolidayFactory'))
 			->setFactory(\Pd\Holidays\HolidayFactory::class, [$translations])
 			->setAutowired(FALSE)
@@ -36,7 +38,7 @@ final class Extension extends \Nette\DI\CompilerExtension
 
 		$localization = $builder
 			->addDefinition($this->prefix($countryCodePrefix))
-			->setFactory($localizationClass, [$czechHolidayFactory])
+			->setFactory($localizationClass, [$holidayFactory])
 			->setAutowired(FALSE)
 		;
 

--- a/src/Localizations/IRomania.php
+++ b/src/Localizations/IRomania.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types = 1);
+
+namespace Pd\Holidays\Localizations;
+
+interface IRomania
+{
+
+	public const COUNTRY_CODE_ROMANIA = 'RO';
+
+}

--- a/src/Localizations/Romania.php
+++ b/src/Localizations/Romania.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types = 1);
+
+namespace Pd\Holidays\Localizations;
+
+class Romania implements \Pd\Holidays\ILocalization
+{
+
+	/** @var array<int, \Pd\Holidays\Year> */
+	private array $years;
+
+	private \Pd\Holidays\HolidayFactory $holidayFactory;
+
+
+	public function __construct(
+		\Pd\Holidays\HolidayFactory $holidayFactory
+	) {
+		$this->holidayFactory = $holidayFactory;
+	}
+
+
+	public function getHolidays(int $year): \Pd\Holidays\IYear
+	{
+		if (isset($this->years[$year])) {
+			return $this->years[$year];
+		}
+
+		$holidays[] = $this->holidayFactory->create(1, 1, '_label_holiday_01_01');
+		$holidays[] = $this->holidayFactory->create(1, 2, '_label_holiday_01_02');
+		$holidays[] = $this->holidayFactory->create(1, 24, '_label_holiday_01_24');
+		$holidays[] = $this->holidayFactory->create(5, 1, '_label_holiday_05_01');
+		$holidays[] = $this->holidayFactory->create(6, 1, '_label_holiday_06_01');
+		$holidays[] = $this->holidayFactory->create(8, 15, '_label_holiday_08_15');
+		$holidays[] = $this->holidayFactory->create(11, 30, '_label_holiday_11_30');
+		$holidays[] = $this->holidayFactory->create(12, 1, '_label_holiday_12_01');
+		$holidays[] = $this->holidayFactory->create(12, 25, '_label_holiday_12_25');
+		$holidays[] = $this->holidayFactory->create(12, 26, '_label_holiday_12_26');
+
+		// velikonoční neděle
+		$easterDateInJulianCalendar = \DateTimeImmutable::createFromFormat('U', (string) \easter_date($year, \CAL_EASTER_ALWAYS_JULIAN));
+		if ($easterDateInJulianCalendar === FALSE) {
+			throw new \Exception('Invalid easter date');
+		}
+		$julianDays = \cal_to_jd(
+			\CAL_JULIAN,
+			(int) $easterDateInJulianCalendar->format('m'),
+			(int) $easterDateInJulianCalendar->format('d'),
+			(int) $easterDateInJulianCalendar->format('Y')
+		);
+		$easterDateInGregorianCalendar = \DateTimeImmutable::createFromFormat('U', (string) \jdtounix($julianDays));
+		if ($easterDateInGregorianCalendar === FALSE) {
+			throw new \Exception('Invalid easter date');
+		}
+
+		// velikonoce
+		$holidays[] = $this->createHoliday($easterDateInGregorianCalendar->modify('-2 day'), '_label_holiday_eastern_friday');
+		$holidays[] = $this->createHoliday($easterDateInGregorianCalendar, '_label_holiday_eastern_sunday');
+		$holidays[] = $this->createHoliday($easterDateInGregorianCalendar->modify('+1 day'), '_label_holiday_eastern_monday');
+
+		// letnice
+		$holidays[] = $this->createHoliday($easterDateInGregorianCalendar->modify('+49 day'), '_label_holiday_pentecost');
+		$holidays[] = $this->createHoliday($easterDateInGregorianCalendar->modify('+50 day'), '_label_holiday_pentecost2');
+
+		$this->years[$year] = new \Pd\Holidays\Year($holidays);
+
+		return $this->years[$year];
+	}
+
+
+	private function createHoliday(\DateTimeInterface $dateTime, string $name): \Pd\Holidays\Holiday
+	{
+		return $this->holidayFactory->create((int) $dateTime->format('n'), (int) $dateTime->format('j'), $name);
+	}
+
+}

--- a/src/Localizations/romania.neon
+++ b/src/Localizations/romania.neon
@@ -1,0 +1,16 @@
+_label_holiday_01_01: Anul Nou
+_label_holiday_01_02: Anul Nou
+_label_holiday_01_24: Ziua Unirii Principatelor Române
+_label_holiday_05_01: Ziua Internațională a Muncii
+_label_holiday_06_01: Ziua Copilului
+_label_holiday_08_15: Adormirea Maicii Domnului
+_label_holiday_11_30: Sfântul Andrei
+_label_holiday_12_01: Ziua Națională a României
+_label_holiday_12_25: Crăciunul
+_label_holiday_12_26: Crăciunul
+_label_holiday_eastern_friday: Vinerea Mare
+_label_holiday_eastern_sunday: Duminica Paștelui
+_label_holiday_eastern_monday: Lunea Luminată
+_label_holiday_pentecost: Rusaliile
+_label_holiday_pentecost2: Rusaliile
+

--- a/tests/Localizations/LocalizationTest.phpt
+++ b/tests/Localizations/LocalizationTest.phpt
@@ -28,6 +28,8 @@ class LocalizationTest extends Tester\TestCase
 			[new Pd\Holidays\Localizations\Slovak($holidayFactory), 2016, 15],
 			[new Pd\Holidays\Localizations\Slovak($holidayFactory), 2017, 15],
 			[new Pd\Holidays\Localizations\Slovak($holidayFactory), 2018, 15],
+			[new Pd\Holidays\Localizations\Slovak($holidayFactory), 2023, 15],
+			[new Pd\Holidays\Localizations\Slovak($holidayFactory), 2025, 15],
 		];
 
 		return $data;


### PR DESCRIPTION
Přidání lokalizace pro rumunsko - https://ro.wikipedia.org/wiki/S%C4%83rb%C4%83tori_publice_%C3%AEn_Rom%C3%A2nia

Velikonoce se na rozdíl od nás řídí juliánským kalendářem.
Letnice jsou taky pohyblivé - velikonoce +50 dní

⚠️ BC break - zahození podpory php 7.4, kvůli druhýmu parametru \easter_date